### PR TITLE
Updated package versions

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -8,14 +8,14 @@
   
   <!-- Included in every project -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
   </ItemGroup>
 
   <!-- Need to be opted in -->
   <ItemGroup>
     
     <!-- DI -->
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.0-preview2.19525.4" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
 
     <!-- SkiaSharp -->
     <PackageReference Update="SkiaSharp"                    Version="1.68.1" />


### PR DESCRIPTION
Haven't tested, yolo.

3.1.0 of DI is out: https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/

2.9.8 Analyzers do stuff: https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/2.9.8
https://github.com/dotnet/roslyn-analyzers/releases