### PR TITLE
Updated look-ahead and claim code

### DIFF
--- a/src/Trains.NET.Engine/GameBoard.cs
+++ b/src/Trains.NET.Engine/GameBoard.cs
@@ -104,8 +104,14 @@ namespace Trains.NET.Engine
                     // If we can't even move the required ammount, we have hit an edge case
                     //  we should deal with it here! Maybe call stop?
 
-                    // Clone our train for lookahead purposes
+                    // Clone our train for look-behind purposes & claim behind us
                     Train dummyTrain = train.Clone();
+                    dummyTrain.SetAngle(dummyTrain.Angle - 180);
+                    // Set our parent as the dummy to abuse the fact no one can pause it
+                    MoveTrain(dummyTrain, dummyTrain, 1.0f, _takenTracks);
+
+                    // Clone our train for look-ahead purposes
+                    dummyTrain = train.Clone();
 
                     // Move our lookahead train clone, traking the tracks we need
                     if (MoveTrain(dummyTrain, train, train.LookaheadDistance - train.DistanceToMove, _takenTracks))

--- a/src/Trains.NET.Engine/GameBoard.cs
+++ b/src/Trains.NET.Engine/GameBoard.cs
@@ -98,22 +98,25 @@ namespace Trains.NET.Engine
                     // Adjust our speed ahead of moving
                     train.AdjustSpeed();
 
+                    // Clone our train for look-behind purposes ahead of moving
+                    //  so we always look the same distance behind irrespective of speed
+                    Train dummyTrain = train.Clone();
+                    dummyTrain.SetAngle(dummyTrain.Angle - 180);
+
                     // Move the actual train by the required distance
                     bool badMove = MoveTrain(train, train, train.DistanceToMove, _takenTracks);
 
                     // If we can't even move the required ammount, we have hit an edge case
                     //  we should deal with it here! Maybe call stop?
 
-                    // Clone our train for look-behind purposes & claim behind us
-                    Train dummyTrain = train.Clone();
-                    dummyTrain.SetAngle(dummyTrain.Angle - 180);
-                    // Set our parent as the dummy to abuse the fact no one can pause it
+                    // Claim behind us & set our parent as the dummy 
+                    //  to abuse the fact no one can pause it
                     MoveTrain(dummyTrain, dummyTrain, 1.0f, _takenTracks);
 
                     // Clone our train for look-ahead purposes
                     dummyTrain = train.Clone();
 
-                    // Move our lookahead train clone, traking the tracks we need
+                    // Move our lookahead train clone, claiming the tracks we cover
                     if (MoveTrain(dummyTrain, train, train.LookaheadDistance - train.DistanceToMove, _takenTracks))
                     {
                         train.Resume();

--- a/src/Trains.NET.Engine/Trains/Train.cs
+++ b/src/Trains.NET.Engine/Trains/Train.cs
@@ -48,6 +48,8 @@ namespace Trains.NET.Engine
 
         public void SetAngle(float angle)
         {
+            while (angle < 0) angle += 360;
+            while (angle > 360) angle -= 360;
             this.Angle = angle;
         }
 


### PR DESCRIPTION
Incoming controversial PR.

An attempt refactoring the claim code.

Major notes:
 - Look ahead is now * 30, this allows the train to come to a stop for given deceleration
 - Minimum look-ahead to remove jerky movement when coming to end of a track
 - Single re-used dictionary
 - Added a "claim-behind" to claim the trailing edge of a train.

This also includes the 'Flagged Trains' PR, as they work in tandem.

Feel free to close, won't be offended, this was done on stream! Woo!!!