### PR TITLE
Fixed double draw

### DIFF
--- a/src/Trains.NET.Comet/MainPage.cs
+++ b/src/Trains.NET.Comet/MainPage.cs
@@ -70,6 +70,9 @@ namespace Trains.NET.Comet
             {
                 game.AdjustViewPortIfNecessary();
 
+                controlDelegate.FlagDraw();
+                _miniMapDelegate.FlagDraw();
+
                 ThreadHelper.Run(async () =>
                 {
                     await ThreadHelper.SwitchToMainThreadAsync();

--- a/src/Trains.NET.Comet/MiniMapDelegate.cs
+++ b/src/Trains.NET.Comet/MiniMapDelegate.cs
@@ -12,6 +12,7 @@ namespace Trains.NET.Comet
     internal class MiniMapDelegate : AbstractControlDelegate, IDisposable
     {
         private bool _redraw = true;
+        private bool _shouldDraw = false;
         private readonly ITrackLayout _trackLayout;
         private readonly IPixelMapper _pixelMapper;
         private readonly ITrackParameters _trackParameters;
@@ -37,8 +38,13 @@ namespace Trains.NET.Comet
             _trackLayout.TracksChanged += (s, e) => _redraw = true;
         }
 
+        public void FlagDraw() => _shouldDraw = true;
+
         public override void Draw(SKCanvas canvas, RectangleF dirtyRect)
         {
+            if (!_shouldDraw) return;
+            _shouldDraw = false;
+
             if (dirtyRect.IsEmpty) return;
             if (!_redraw) return;
 

--- a/src/Trains.NET.Comet/TrainsDelegate.cs
+++ b/src/Trains.NET.Comet/TrainsDelegate.cs
@@ -17,6 +17,7 @@ namespace Trains.NET.Comet
         private readonly Factory<IToolPreviewer> _previewerFactory;
         private (int column, int row) _lastDragCell;
         private bool _dragging;
+        private bool _shouldDraw = false;
         private float _mouseX;
         private float _mouseY;
 
@@ -34,9 +35,14 @@ namespace Trains.NET.Comet
             _game.SetSize((int)bounds.Width, (int)bounds.Height);
         }
 
+        public void FlagDraw() => _shouldDraw = true;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "<Pending>")]
         public override void Draw(SkiaSharp.SKCanvas canvas, RectangleF dirtyRect)
         {
+            if (!_shouldDraw) return;
+            _shouldDraw = false;
+
             _game.Render(new SKCanvasWrapper(canvas));
 
             if (this.CurrentTool.Value is ICustomCursor cursor)


### PR DESCRIPTION
Somewhere in Skia/Comet invalidate is being called causing it to draw multiple times (often seen as the FPS jumping up!).

By just simply flagging when we should draw, and ignoring all other calls, this seems to resolve the issue and in turn stop the UI from locking up as much.