### PR TITLE
EXPERIMENTAL: Removed DPI scaling, made mouse & size code DPI aware

### DIFF
--- a/src/Trains.NET.Comet/MiniMapDelegate.cs
+++ b/src/Trains.NET.Comet/MiniMapDelegate.cs
@@ -12,6 +12,7 @@ namespace Trains.NET.Comet
     internal class MiniMapDelegate : AbstractControlDelegate, IDisposable
     {
         private bool _redraw = true;
+        private float _dpi = 1.0f;
         private readonly ITrackLayout _trackLayout;
         private readonly IPixelMapper _pixelMapper;
         private readonly ITrackParameters _trackParameters;
@@ -42,6 +43,14 @@ namespace Trains.NET.Comet
             if (dirtyRect.IsEmpty) return;
             if (!_redraw) return;
 
+            // Pull DPI from caller scale
+            float newDpi = canvas.TotalMatrix.ScaleX;
+            if (float.IsFinite(newDpi))
+            {
+                _dpi = newDpi;
+            }
+            canvas.RestoreToCount(-1);
+
             const int maxGridSize = PixelMapper.MaxGridSize;
             using var bitmap = new SKBitmap(maxGridSize, maxGridSize);
 
@@ -68,10 +77,14 @@ namespace Trains.NET.Comet
             return true;
         }
 
+        private (float x, float y) ConvertDPIScaledPointToRawPosition(PointF point) => (point.X * _dpi, point.Y * _dpi);
+
         public override void DragInteraction(PointF[] points)
         {
-            float x = points[0].X * (PixelMapper.MaxGridSize / 100);
-            float y = points[0].Y * (PixelMapper.MaxGridSize / 100);
+            (float mouseX, float mouseY) = ConvertDPIScaledPointToRawPosition(points[0]);
+
+            float x = mouseX * (PixelMapper.MaxGridSize / 100);
+            float y = mouseY * (PixelMapper.MaxGridSize / 100);
 
             x -= _pixelMapper.ViewPortWidth / 2;
             y -= _pixelMapper.ViewPortHeight / 2;


### PR DESCRIPTION
This is an experimental PR that removes DPI scaling of the canvas in order to reduce draw time.

Without changes, 7ms draw time (and not drawing all tracks :P):
![image](https://user-images.githubusercontent.com/20675893/88144741-c1d09d80-cc3c-11ea-8ab7-9e0387c189eb.png)

With changes, 4ms draw time.
![image](https://user-images.githubusercontent.com/20675893/88144535-6bfbf580-cc3c-11ea-8ee6-77c4c86d5b51.png)

It is marked as experimental as trains could appear smaller on screen for those with high scaling settings. I'd like to open a discussion as we could theoretically counter this by scaling cellSize by this DPI scale. This in turn open the question of should zoom be supported, and if so, should this be done by cell size as well?