### PR TITLE
Added dirty flag to NatureRenderer (Memory Utilization Fix)

### DIFF
--- a/src/Trains.NET.Rendering/Nature/NatureRenderer.cs
+++ b/src/Trains.NET.Rendering/Nature/NatureRenderer.cs
@@ -6,20 +6,23 @@ namespace Trains.NET.Rendering
     internal class NatureRenderer : ICachableLayerRenderer
     {
         private readonly ITreeRenderer _treeRenderer;
-        private readonly ILayout _collection;
+        private readonly ILayout<Tree> _collection;
         private readonly ITrackParameters _parameters;
+        private bool _dirty;
 
-        public bool IsDirty => true;
+        public bool IsDirty => _dirty;
 
         public bool Enabled { get; set; } = true;
 
         public string Name => "Nature";
 
-        public NatureRenderer(ITreeRenderer treeRenderer, ILayout collection, ITrackParameters parameters)
+        public NatureRenderer(ITreeRenderer treeRenderer, ILayout<Tree> collection, ITrackParameters parameters)
         {
             _treeRenderer = treeRenderer;
             _collection = collection;
             _parameters = parameters;
+
+            _collection.CollectionChanged += (s, e) => _dirty = true;
         }
 
         public void Render(ICanvas canvas, int width, int height, IPixelMapper pixelMapper)
@@ -40,6 +43,7 @@ namespace Trains.NET.Rendering
 
                 canvas.Restore();
             }
+            _dirty = false;
         }
     }
 }


### PR DESCRIPTION
It looks like nature being constantly dirty (and rebuilding the cached layer) is causing the odd memory usage.

**With this PR:**
![image](https://user-images.githubusercontent.com/20675893/89992950-6177cd80-dcc9-11ea-889b-64e903ed1c59.png)

**Pre-PR master:**
![image](https://user-images.githubusercontent.com/20675893/89993105-92f09900-dcc9-11ea-8ef5-7645f270feeb.png)
