### PR TITLE
We weren't generating terrain type when new cell was being generated …

### DIFF
--- a/src/Trains.NET.Engine/Terrain/TerrainMap.cs
+++ b/src/Trains.NET.Engine/Terrain/TerrainMap.cs
@@ -34,7 +34,7 @@ namespace Trains.NET.Engine.Tracks
             (int, int) key = (column, row);
             Terrain terrain = _terrainMap.ContainsKey(key)
                 ? _terrainMap[key]
-                : new Terrain { Column = column, Row = row };
+                : new Terrain { Column = column, Row = row, TerrainType = TerrainType.Grass };
 
             _terrainMap = _terrainMap.Add(key, transform(terrain));
         }


### PR DESCRIPTION
…for height, so it was defaulting to the first enum value (water). Given background is grass, change the terrain type for newly generated terrain to grass.