### PR TITLE
Added indent style to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,7 @@
 
 [*.cs]
+indent_style = space
+indent_size = 4
 
 # Default severity for all analyzer diagnostics
 dotnet_analyzer_diagnostic.severity = none


### PR DESCRIPTION
I won't point fingers, but someone involved in the last livestream had their indent settings different from the rest of the project.

![image](https://user-images.githubusercontent.com/278957/91556416-4c6d8200-e8f8-11ea-92ce-49c752a58cd9.png)

Since David has visible whitespace enabled, viewers must suffer seeing the mixed tabs and spaces. This PR addresses the issue by suppressing individuality.