### PR TITLE
Draw terrain from a backing image.

### DIFF
--- a/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
+++ b/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
@@ -25,7 +25,7 @@ namespace Trains.NET.Rendering.Skia
             if (!s_paintCache.TryGetValue(paint, out SKPaint skPaint))
             {
                 skPaint = paint.ToSkia();
-                s_paintCache.Add(paint, skPaint);
+                s_paintCache[paint] = skPaint;
             }
             return skPaint;
         }

--- a/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
+++ b/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
@@ -8,6 +8,12 @@ namespace Trains.NET.Rendering.Skia
     {
         private static readonly Dictionary<PaintBrush, SKPaint> s_paintCache = new();
 
+        private static readonly SKPaint s_noAntialiasPaint = new SKPaint
+        {
+            IsAntialias = false,
+            IsDither = false
+        };
+
         private readonly SkiaSharp.SKCanvas _canvas;
 
         public SKCanvasWrapper(SkiaSharp.SKCanvas canvas)
@@ -37,6 +43,9 @@ namespace Trains.NET.Rendering.Skia
 
         public void DrawImage(IImage image, int x, int y)
             => _canvas.DrawImage(image.ToSkia(), x, y);
+
+        public void DrawImage(IImage image, Rectangle sourceRectangle, Rectangle destinationRectangle)
+            => _canvas.DrawImage(image.ToSkia(), sourceRectangle.ToSkia(), destinationRectangle.ToSkia(), s_noAntialiasPaint);
 
 
         public void DrawCircle(float x, float y, float radius, PaintBrush paint)

--- a/src/Trains.NET.Rendering/Drawing/ICanvas.cs
+++ b/src/Trains.NET.Rendering/Drawing/ICanvas.cs
@@ -20,5 +20,6 @@ namespace Trains.NET.Rendering
         void Scale(float scaleX, float scaleY);
         void DrawImage(IImage cachedImage, int x, int y);
         float MeasureText(string text, PaintBrush paint);
+        void DrawImage(IImage image, Rectangle sourceRectangle, Rectangle destinationRectangle);
     }
 }

--- a/src/Trains.NET.Rendering/LayerRenderer/TerrainLayerRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/TerrainLayerRenderer.cs
@@ -1,0 +1,47 @@
+﻿using Trains.NET.Engine;
+
+namespace Trains.NET.Rendering
+{
+    [Order(0)]
+    // Terrain layer has its own efficient caching, so doesn't need to be an ICachedLayerRenderer
+    public class TerrainLayerRenderer : ILayerRenderer
+    {
+        private readonly ITerrainMapRenderer _terrainMapRenderer;
+
+        public TerrainLayerRenderer(ITerrainMapRenderer terrainMapRenderer)
+        {
+            _terrainMapRenderer = terrainMapRenderer;
+        }
+
+        public bool Enabled { get; set; } = true;
+        public string Name => "Terrain";
+
+        public void Render(ICanvas canvas, int width, int height, IPixelMapper pixelMapper)
+        {
+            if(_terrainMapRenderer.TryGetTerrainImage(out IImage? terrainImage))
+            {
+                (Rectangle source, Rectangle destination) = GetSourceAndDestinationRectangles(pixelMapper);
+
+                canvas.DrawImage(terrainImage, source, destination);
+            }
+        }
+
+        private static (Rectangle Source, Rectangle Destination) GetSourceAndDestinationRectangles(IPixelMapper pixelMapper)
+        {
+            (int topLeftColumn, int topLeftRow) = pixelMapper.ViewPortPixelsToCoords(0, 0);
+            (int bottomRightColumn, int bottomRightRow) = pixelMapper.ViewPortPixelsToCoords(pixelMapper.ViewPortWidth, pixelMapper.ViewPortHeight);
+
+            bottomRightColumn += 1;
+            bottomRightRow += 1;
+
+            Rectangle source = new(topLeftColumn, topLeftRow, bottomRightColumn, bottomRightRow);
+
+            (int destinationTopLeftX, int destinationTopLeftY, _) = pixelMapper.CoordsToViewPortPixels(topLeftColumn, topLeftRow);
+            (int destinationBottomRightX, int destinationBottomRightY, _) = pixelMapper.CoordsToViewPortPixels(bottomRightColumn, bottomRightRow);
+
+            Rectangle destination = new(destinationTopLeftX, destinationTopLeftY, destinationBottomRightX, destinationBottomRightY);
+
+            return (source, destination);
+        }
+    }
+}

--- a/src/Trains.NET.Rendering/PixelMapper.cs
+++ b/src/Trains.NET.Rendering/PixelMapper.cs
@@ -93,7 +93,9 @@ namespace Trains.NET.Rendering
                  ViewPortY = this.ViewPortY,
                  ViewPortHeight = this.ViewPortHeight,
                  ViewPortWidth = this.ViewPortWidth,
-                 GameScale = this.GameScale
+                 GameScale = this.GameScale,
+                 _columns = _columns,
+                 _rows = _rows
             };
         }
     }

--- a/src/Trains.NET.Rendering/Terrain/ITerrainMapRenderer.cs
+++ b/src/Trains.NET.Rendering/Terrain/ITerrainMapRenderer.cs
@@ -1,0 +1,9 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Trains.NET.Rendering
+{
+    public interface ITerrainMapRenderer
+    {
+        bool TryGetTerrainImage([NotNullWhen(true)] out IImage? image);
+    }
+}


### PR DESCRIPTION
Instead of redrawing CellSize squares all the time, build out a 1 Cell == 1 Pixel backing image (in game dev this would be a texture) and then use a "source" and "destination" rectangle set to draw this at the right scale to the viewport.

Turns out, this is FAST:
![image](https://user-images.githubusercontent.com/20675893/91627939-9476cc80-e9fe-11ea-8f7f-b8ace756da80.png)
