### PR TITLE
Pixel mapper fixes

### DIFF
--- a/src/Trains.NET.Comet/MainPage.cs
+++ b/src/Trains.NET.Comet/MainPage.cs
@@ -61,10 +61,10 @@ namespace Trains.NET.Comet
                         new Spacer(),
                         new HStack()
                         {
-                            new Button(" - ", () => _game.Zoom(-1))
+                            new Button(" - ", () => _game.ZoomOut())
                                 .Frame(40),
                             new Spacer(),
-                            new Button(" + ", () => _game.Zoom(1))
+                            new Button(" + ", () => _game.ZoomIn())
                                 .Frame(40),
                         },
                         new Spacer(),

--- a/src/Trains.NET.Rendering/Game/Game.cs
+++ b/src/Trains.NET.Rendering/Game/Game.cs
@@ -202,26 +202,11 @@ namespace Trains.NET.Rendering
             _gameBoard.Dispose();
         }
 
-        private const float ZoomStep = 0.25f;
-        private const int ZoomLevels = 20;
+        private const float ZoomInDelta = 1.25f;
+        private const float ZoomOutDelta = 1f / ZoomInDelta;
 
-        public void Zoom(float zoomDelta)
-        {
-            float newScale = _pixelMapper.GameScale + zoomDelta * ZoomStep;
+        public void ZoomOut() => _pixelMapper.AdjustGameScale(ZoomOutDelta);
 
-            if(newScale < ZoomStep)
-            {
-                newScale = ZoomStep;
-            }
-
-            float maxZoomScale = ZoomStep * (ZoomLevels + 1);
-
-            if (newScale > maxZoomScale)
-            {
-                newScale = maxZoomScale;
-            }
-
-            _pixelMapper.GameScale = newScale;
-        }
+        public void ZoomIn() => _pixelMapper.AdjustGameScale(ZoomInDelta);
     }
 }

--- a/src/Trains.NET.Rendering/Game/IGame.cs
+++ b/src/Trains.NET.Rendering/Game/IGame.cs
@@ -9,6 +9,7 @@ namespace Trains.NET.Rendering
         void Render(ICanvas canvas);
         void SetSize(int width, int height);
         (int Width, int Height) GetSize();
-        void Zoom(float zoomDelta);
+        void ZoomIn();
+        void ZoomOut();
     }
 }

--- a/src/Trains.NET.Rendering/IPixelMapper.cs
+++ b/src/Trains.NET.Rendering/IPixelMapper.cs
@@ -10,7 +10,7 @@ namespace Trains.NET.Rendering
         int ViewPortY { get; }
         int ViewPortWidth { get; }
         int ViewPortHeight { get; }
-        float GameScale { get; set; }
+        float GameScale { get; }
         int CellSize { get; }
         int MaxGridSize { get; }
 
@@ -23,5 +23,6 @@ namespace Trains.NET.Rendering
         void SetViewPort(int x, int y);
         IPixelMapper Snapshot();
         void Initialize(int v1, int v2);
+        void AdjustGameScale(float delta);
     }
 }

--- a/src/Trains.NET.Rendering/PixelMapper.cs
+++ b/src/Trains.NET.Rendering/PixelMapper.cs
@@ -28,6 +28,7 @@ namespace Trains.NET.Rendering
         {
             this.ViewPortWidth = width;
             this.ViewPortHeight = height;
+            AdjustViewPort(0, 0);
         }
 
         public void SetViewPort(int x, int y)


### PR DESCRIPTION
 - Moved the responsibility of zoom values into game (ZoomIn, ZoomOut)
 - Calculated the ZoomIn/ZoomOut values to be equal (1 Zoom In + 1 Zoom Out puts you back in the same place)
 - Fixed a comparison issue in the OnScreen part of CoordsToViewPortPixels
 - Made SetViewportSize call AdjustViewportSize to move it back into bounds if the resize take the viewport beyond the game
 - Adjust game scale now keeps the screen centered!!!!!!!!!! :D :D : D
   - Moved from code on the Setter to a new AdjustGameScale call.
 - Snapshot now clones _rows and _columns so MaxGridSize works on a snapshot