### PR TITLE
Better caching

### DIFF
--- a/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
+++ b/src/Trains.NET.Rendering.Skia/SKCanvasWrapper.cs
@@ -25,7 +25,7 @@ namespace Trains.NET.Rendering.Skia
             if (!s_paintCache.TryGetValue(paint, out SKPaint skPaint))
             {
                 skPaint = paint.ToSkia();
-                s_paintCache[paint] = skPaint;
+                s_paintCache.Add(paint, skPaint);
             }
             return skPaint;
         }

--- a/src/Trains.NET.Rendering/Drawing/IImageCache.cs
+++ b/src/Trains.NET.Rendering/Drawing/IImageCache.cs
@@ -7,7 +7,7 @@ namespace Trains.NET.Rendering
     [Transient]
     public interface IImageCache : IDisposable
     {
-        IImage Get(object key);
+        IImage? Get(object key);
         void Set(object key, IImage image);
         bool IsDirty(object key);
         void SetDirty(object key);

--- a/src/Trains.NET.Rendering/Drawing/IImageCache.cs
+++ b/src/Trains.NET.Rendering/Drawing/IImageCache.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using Trains.NET.Engine;
+
+namespace Trains.NET.Rendering
+{
+    [Transient]
+    public interface IImageCache : IDisposable
+    {
+        IImage Get(object key);
+        void Set(object key, IImage image);
+        bool IsDirty(object key);
+        void SetDirty(object key);
+        void Clear();
+        void SetDirtyAll(IEnumerable<object> keys);
+    }
+}

--- a/src/Trains.NET.Rendering/Drawing/ImageCache.cs
+++ b/src/Trains.NET.Rendering/Drawing/ImageCache.cs
@@ -18,7 +18,7 @@ namespace Trains.NET.Rendering.Drawing
             }
         }
 
-        public IImage Get(object key)
+        public IImage? Get(object key)
         {
             lock (_cacheLock)
             {

--- a/src/Trains.NET.Rendering/Drawing/ImageCache.cs
+++ b/src/Trains.NET.Rendering/Drawing/ImageCache.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Trains.NET.Rendering.Drawing
+{
+    public class ImageCache : IImageCache
+    {
+        private readonly object _cacheLock = new object();
+
+        private readonly Dictionary<object, IImage> _imageBuffer = new();
+        private readonly Dictionary<object, bool> _dirtySTate = new();
+
+        public void Clear()
+        {
+            foreach (object key in _dirtySTate.Keys.ToArray())
+            {
+                _dirtySTate[key] = true;
+            }
+        }
+
+        public IImage Get(object key)
+        {
+            lock (_cacheLock)
+            {
+                return _imageBuffer.GetValueOrDefault(key);
+            }
+        }
+
+        public bool IsDirty(object key)
+        {
+            return _dirtySTate.GetValueOrDefault(key) || !_imageBuffer.ContainsKey(key);
+        }
+
+        public void SetDirty(object key)
+        {
+            _dirtySTate[key] = true;
+        }
+
+        public void SetDirtyAll(IEnumerable<object> keys)
+        {
+            foreach (object key in keys)
+            {
+                SetDirty(key);
+            }
+        }
+
+        public void Set(object key, IImage image)
+        {
+            lock (_cacheLock)
+            {
+                if (_imageBuffer.TryGetValue(key, out IImage existing))
+                {
+                    existing.Dispose();
+                }
+                _imageBuffer[key] = image;
+                _dirtySTate[key] = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_cacheLock)
+            {
+                foreach (IImage image in _imageBuffer.Values)
+                {
+                    image.Dispose();
+                }
+                _imageBuffer.Clear();
+                _dirtySTate.Clear();
+            }
+        }
+    }
+}

--- a/src/Trains.NET.Rendering/Game/Game.cs
+++ b/src/Trains.NET.Rendering/Game/Game.cs
@@ -119,7 +119,7 @@ namespace Trains.NET.Rendering
                 return;
             }
 
-            IImage gameImage = _imageCache.Get(this);
+            IImage? gameImage = _imageCache.Get(this);
             if (gameImage != null)
             {
                 canvas.DrawImage(gameImage, 0, 0);
@@ -141,21 +141,20 @@ namespace Trains.NET.Rendering
 
             AdjustViewPortIfNecessary();
 
-            IPixelMapper? pixelMapper = _pixelMapper.Snapshot();
+            IPixelMapper pixelMapper = _pixelMapper.Snapshot();
 
             using IImageCanvas imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
 
-            ICanvas? canvas = imageCanvas.Canvas;
-            RenderFrame(canvas, pixelMapper);
+            RenderFrame(imageCanvas.Canvas, pixelMapper);
 
             _imageCache.Set(this, imageCanvas.Render());
 
-            foreach (IScreen? screen in _screens)
+            foreach (IScreen screen in _screens)
             {
                 if (_imageCache.IsDirty(screen))
                 {
                     _screenDrawTimes[screen].Start();
-                    using IImageCanvas? screnCanvas = _imageFactory.CreateImageCanvas(_screenWidth, _screenHeight);
+                    using IImageCanvas screnCanvas = _imageFactory.CreateImageCanvas(_screenWidth, _screenHeight);
                     screen.Render(screnCanvas.Canvas, _screenWidth, _screenHeight);
                     _screenDrawTimes[screen].Stop();
                     _imageCache.Set(screen, screnCanvas.Render());
@@ -163,13 +162,8 @@ namespace Trains.NET.Rendering
             }
         }
 
-        private void RenderFrame(ICanvas? canvas, IPixelMapper pixelMapper)
+        private void RenderFrame(ICanvas canvas, IPixelMapper pixelMapper)
         {
-            if (canvas is null)
-            {
-                throw new ArgumentNullException(nameof(canvas));
-            }
-
             _skiaDrawTime.Start();
 
             canvas.Save();
@@ -188,14 +182,14 @@ namespace Trains.NET.Rendering
                     {
                         _renderCacheDrawTimes[renderer].Start();
 
-                        using IImageCanvas? imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
+                        using IImageCanvas imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
                         renderer.Render(imageCanvas.Canvas, _width, _height, pixelMapper);
                         _imageCache.Set(renderer, imageCanvas.Render());
                         _renderCacheDrawTimes[renderer].Stop();
                     }
 
                     _renderLayerDrawTimes[renderer].Start();
-                    canvas.DrawImage(_imageCache.Get(renderer), 0, 0);
+                    canvas.DrawImage(_imageCache.Get(renderer)!, 0, 0);
                     _renderLayerDrawTimes[renderer].Stop();
                 }
                 else
@@ -214,7 +208,7 @@ namespace Trains.NET.Rendering
 
         public void AdjustViewPortIfNecessary()
         {
-            foreach (IMovable? vehicle in _gameBoard.GetMovables())
+            foreach (IMovable vehicle in _gameBoard.GetMovables())
             {
                 if (vehicle.Follow)
                 {

--- a/src/Trains.NET.Rendering/Game/Game.cs
+++ b/src/Trains.NET.Rendering/Game/Game.cs
@@ -11,10 +11,6 @@ namespace Trains.NET.Rendering
     {
         private const int RenderInterval = 16;
 
-        private readonly object _bufferLock = new object();
-        private IImage? _backBuffer;
-
-        private bool _needsBufferReset;
         private int _width;
         private int _height;
         private int _screenWidth;
@@ -25,21 +21,20 @@ namespace Trains.NET.Rendering
         private readonly IImageFactory _imageFactory;
         private readonly PerSecondTimedStat _skiaFps = InstrumentationBag.Add<PerSecondTimedStat>("Draw-FPS-Skia");
         private readonly ElapsedMillisecondsTimedStat _skiaDrawTime = InstrumentationBag.Add<ElapsedMillisecondsTimedStat>("Draw-Skia-AllUp");
-        private readonly ElapsedMillisecondsTimedStat _gameBufferReset = InstrumentationBag.Add<ElapsedMillisecondsTimedStat>("Draw-Game-BufferReset");
         private readonly Dictionary<ILayerRenderer, ElapsedMillisecondsTimedStat> _renderLayerDrawTimes;
         private readonly Dictionary<IScreen, ElapsedMillisecondsTimedStat> _screenDrawTimes;
         private readonly Dictionary<ILayerRenderer, ElapsedMillisecondsTimedStat> _renderCacheDrawTimes;
-        private readonly Dictionary<ILayerRenderer, IImage> _imageBuffer = new();
         private readonly ITimer _renderLoop;
         private readonly IEnumerable<IScreen> _screens;
-        private readonly Dictionary<IScreen, IImage> _screenCache = new Dictionary<IScreen, IImage>();
+        private readonly IImageCache _imageCache;
 
         public Game(IGameBoard gameBoard,
                     IEnumerable<ILayerRenderer> boardRenderers,
                     IPixelMapper pixelMapper,
                     IImageFactory imageFactory,
                     ITimer renderLoop,
-                    IEnumerable<IScreen> screens)
+                    IEnumerable<IScreen> screens,
+                    IImageCache imageCache)
         {
             _gameBoard = gameBoard;
             _boardRenderers = boardRenderers;
@@ -47,16 +42,21 @@ namespace Trains.NET.Rendering
             _imageFactory = imageFactory;
             _renderLoop = renderLoop;
             _screens = screens;
+            _imageCache = imageCache;
 
-            foreach (var screen in _screens)
+            foreach (IScreen screen in _screens)
             {
-                screen.Changed += (s, e) => _screenCache.Remove(screen);
+                screen.Changed += (s, e) => _imageCache.SetDirty(screen);
+            }
+            foreach (ICachableLayerRenderer renderer in _boardRenderers.OfType<ICachableLayerRenderer>())
+            {
+                renderer.Changed += (s, e) => _imageCache.SetDirty(renderer);
             }
 
             _renderLayerDrawTimes = _boardRenderers.ToDictionary(x => x, x => InstrumentationBag.Add<ElapsedMillisecondsTimedStat>(GetLayerDiagnosticsName(x)));
             _screenDrawTimes = _screens.ToDictionary(x => x, x => InstrumentationBag.Add<ElapsedMillisecondsTimedStat>(GetLayerDiagnosticsName(x)));
             _renderCacheDrawTimes = _boardRenderers.Where(x => x is ICachableLayerRenderer).ToDictionary(x => x, x => InstrumentationBag.Add<ElapsedMillisecondsTimedStat>("Draw-Cache-" + x.Name.Replace(" ", "")));
-            _pixelMapper.ViewPortChanged += (s, e) => _needsBufferReset = true;
+            _pixelMapper.ViewPortChanged += (s, e) => _imageCache.SetDirtyAll(_boardRenderers);
 
             _renderLoop.Elapsed += (s, e) => DrawFrame();
             _renderLoop.Interval = RenderInterval;
@@ -88,7 +88,7 @@ namespace Trains.NET.Rendering
             _screenWidth = width;
             _screenHeight = height;
 
-            _screenCache.Clear();
+            _imageCache.SetDirtyAll(_screens);
 
             (int columns, int rows) = _pixelMapper.ViewPortPixelsToCoords(width, height);
             columns = Math.Max(columns, 1);
@@ -102,7 +102,9 @@ namespace Trains.NET.Rendering
                 _height = height;
                 _pixelMapper.SetViewPortSize(_width, _height);
 
-                _needsBufferReset = true;
+                // strictly speaking this only needs to clear renderers, but we already cleared screens
+                // so its easier just to call clear
+                _imageCache.Clear();
             }
         }
 
@@ -117,26 +119,19 @@ namespace Trains.NET.Rendering
                 return;
             }
 
-            lock (_bufferLock)
+            IImage gameImage = _imageCache.Get(this);
+            if (gameImage != null)
             {
-                if (_backBuffer != null)
-                {
-                    canvas.DrawImage(_backBuffer, 0, 0);
-                }
+                canvas.DrawImage(gameImage, 0, 0);
             }
 
-            foreach (var screen in _screens)
+            foreach (IScreen screen in _screens)
             {
-                if (!_screenCache.TryGetValue(screen, out var image))
+                IImage? screenImage = _imageCache.Get(screen);
+                if (screenImage != null)
                 {
-                    _screenDrawTimes[screen].Start();
-                    using var imageCanvas = _imageFactory.CreateImageCanvas(_screenWidth, _screenHeight);
-                    screen.Render(imageCanvas.Canvas, _screenWidth, _screenHeight);
-                    _screenDrawTimes[screen].Stop();
-                    image = imageCanvas.Render();
-                    _screenCache.Add(screen, image);
+                    canvas.DrawImage(screenImage, 0, 0);
                 }
-                canvas.DrawImage(image, 0, 0);
             }
         }
 
@@ -148,30 +143,23 @@ namespace Trains.NET.Rendering
 
             IPixelMapper? pixelMapper = _pixelMapper.Snapshot();
 
-            using IImageCanvas? imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
+            using IImageCanvas imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
 
             ICanvas? canvas = imageCanvas.Canvas;
             RenderFrame(canvas, pixelMapper);
 
-            IImage? oldBuffer = _backBuffer;
-            lock (_bufferLock)
-            {
-                _backBuffer = imageCanvas.Render();
-            }
-            oldBuffer?.Dispose();
+            _imageCache.Set(this, imageCanvas.Render());
 
-            if (_needsBufferReset)
+            foreach (IScreen? screen in _screens)
             {
-                _gameBufferReset.Start();
-
-                foreach (IImage image in _imageBuffer.Values)
+                if (_imageCache.IsDirty(screen))
                 {
-                    image.Dispose();
+                    _screenDrawTimes[screen].Start();
+                    using IImageCanvas? screnCanvas = _imageFactory.CreateImageCanvas(_screenWidth, _screenHeight);
+                    screen.Render(screnCanvas.Canvas, _screenWidth, _screenHeight);
+                    _screenDrawTimes[screen].Stop();
+                    _imageCache.Set(screen, screnCanvas.Render());
                 }
-                _imageBuffer.Clear();
-
-                _needsBufferReset = false;
-                _gameBufferReset.Stop();
             }
         }
 
@@ -196,18 +184,18 @@ namespace Trains.NET.Rendering
 
                 if (renderer is ICachableLayerRenderer cachable)
                 {
-                    if (cachable.IsDirty || !_imageBuffer.ContainsKey(renderer))
+                    if (_imageCache.IsDirty(renderer))
                     {
                         _renderCacheDrawTimes[renderer].Start();
 
                         using IImageCanvas? imageCanvas = _imageFactory.CreateImageCanvas(_width, _height);
                         renderer.Render(imageCanvas.Canvas, _width, _height, pixelMapper);
-                        _imageBuffer[renderer] = imageCanvas.Render();
+                        _imageCache.Set(renderer, imageCanvas.Render());
                         _renderCacheDrawTimes[renderer].Stop();
                     }
 
                     _renderLayerDrawTimes[renderer].Start();
-                    canvas.DrawImage(_imageBuffer[renderer], 0, 0);
+                    canvas.DrawImage(_imageCache.Get(renderer), 0, 0);
                     _renderLayerDrawTimes[renderer].Stop();
                 }
                 else
@@ -247,7 +235,7 @@ namespace Trains.NET.Rendering
 
         public void Dispose()
         {
-            _backBuffer?.Dispose();
+            _imageCache.Dispose();
             _renderLoop.Dispose();
             _gameBoard.Dispose();
         }

--- a/src/Trains.NET.Rendering/Game/Game.cs
+++ b/src/Trains.NET.Rendering/Game/Game.cs
@@ -229,8 +229,8 @@ namespace Trains.NET.Rendering
 
         public void Dispose()
         {
-            _imageCache.Dispose();
             _renderLoop.Dispose();
+            _imageCache.Dispose();
             _gameBoard.Dispose();
         }
 

--- a/src/Trains.NET.Rendering/LayerRenderer/Bases/CachableLayoutRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/Bases/CachableLayoutRenderer.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Trains.NET.Engine;
 
 namespace Trains.NET.Rendering
 {
     public abstract class CachableLayoutRenderer<T> : LayoutRenderer<T>, ICachableLayerRenderer where T : class, IStaticEntity
     {
-        private bool _dirty;
-
-        public bool IsDirty => _dirty;
+        public event EventHandler? Changed;
 
         public CachableLayoutRenderer(ILayout<T> layout, IRenderer<T> renderer, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
             : this(layout, new[] { renderer }, imageFactory, terrainMap, imageCache)
@@ -17,14 +16,7 @@ namespace Trains.NET.Rendering
         public CachableLayoutRenderer(ILayout<T> layout, IEnumerable<IRenderer<T>> renderers, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
             : base (layout, renderers, imageFactory, terrainMap, imageCache)
         {
-            layout.CollectionChanged += (s, e) => _dirty = true;
-        }
-
-        public new void Render(ICanvas canvas, int width, int height, IPixelMapper pixelMapper)
-        {
-            base.Render(canvas, width, height, pixelMapper);
-
-            _dirty = false;
+            layout.CollectionChanged += (s, e) => Changed?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Trains.NET.Rendering/LayerRenderer/Bases/CachableLayoutRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/Bases/CachableLayoutRenderer.cs
@@ -9,13 +9,13 @@ namespace Trains.NET.Rendering
 
         public bool IsDirty => _dirty;
 
-        public CachableLayoutRenderer(ILayout<T> layout, IRenderer<T> renderer, IImageFactory imageFactory, ITerrainMap terrainMap)
-            : this(layout, new[] { renderer }, imageFactory, terrainMap)
+        public CachableLayoutRenderer(ILayout<T> layout, IRenderer<T> renderer, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
+            : this(layout, new[] { renderer }, imageFactory, terrainMap, imageCache)
         {
         }
 
-        public CachableLayoutRenderer(ILayout<T> layout, IEnumerable<IRenderer<T>> renderers, IImageFactory imageFactory, ITerrainMap terrainMap)
-            : base (layout, renderers, imageFactory, terrainMap)
+        public CachableLayoutRenderer(ILayout<T> layout, IEnumerable<IRenderer<T>> renderers, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
+            : base (layout, renderers, imageFactory, terrainMap, imageCache)
         {
             layout.CollectionChanged += (s, e) => _dirty = true;
         }

--- a/src/Trains.NET.Rendering/LayerRenderer/Bases/ICachableLayerRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/Bases/ICachableLayerRenderer.cs
@@ -1,7 +1,9 @@
-﻿namespace Trains.NET.Rendering
+﻿using System;
+
+namespace Trains.NET.Rendering
 {
     public interface ICachableLayerRenderer : ILayerRenderer
     {
-        bool IsDirty { get; }
+        event EventHandler? Changed;
     }
 }

--- a/src/Trains.NET.Rendering/LayerRenderer/Bases/LayoutRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/Bases/LayoutRenderer.cs
@@ -81,7 +81,7 @@ namespace Trains.NET.Rendering
                             _imageCache.Set(key, imageCanvas.Render());
                         }
 
-                        canvas.DrawImage(_imageCache.Get(key), 0, 0);
+                        canvas.DrawImage(_imageCache.Get(key)!, 0, 0);
                     }
                     else
                     {

--- a/src/Trains.NET.Rendering/LayerRenderer/GridRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/GridRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Trains.NET.Engine;
+﻿using System;
+using Trains.NET.Engine;
 
 namespace Trains.NET.Rendering
 {
@@ -7,7 +8,8 @@ namespace Trains.NET.Rendering
     {
         public bool Enabled { get; set; }
         public string Name => "Grid";
-        public bool IsDirty => false;
+
+        public event EventHandler? Changed;
 
         public void Render(ICanvas canvas, int width, int height, IPixelMapper pixelMapper)
         {

--- a/src/Trains.NET.Rendering/LayerRenderer/GridRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/GridRenderer.cs
@@ -4,7 +4,7 @@ using Trains.NET.Engine;
 namespace Trains.NET.Rendering
 {
     [Order(1)]
-    public class GridRenderer : ILayerRenderer, ICachableLayerRenderer
+    public class GridRenderer : ICachableLayerRenderer
     {
         public bool Enabled { get; set; }
         public string Name => "Grid";

--- a/src/Trains.NET.Rendering/LayerRenderer/NatureLayoutRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/NatureLayoutRenderer.cs
@@ -5,8 +5,8 @@ namespace Trains.NET.Rendering
     [Order(450)]
     public class NatureLayoutRenderer : CachableLayoutRenderer<Tree>
     {
-        public NatureLayoutRenderer(ILayout<Tree> layout, IRenderer<Tree> renderer, IImageFactory imageFactory, ITerrainMap terrainMap)
-                : base(layout, renderer, imageFactory, terrainMap)
+        public NatureLayoutRenderer(ILayout<Tree> layout, IRenderer<Tree> renderer, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
+                : base(layout, renderer, imageFactory, terrainMap, imageCache)
         {
             this.Name = "Nature";
             this.Enabled = true;

--- a/src/Trains.NET.Rendering/LayerRenderer/TrackLayoutRenderer.cs
+++ b/src/Trains.NET.Rendering/LayerRenderer/TrackLayoutRenderer.cs
@@ -6,8 +6,8 @@ namespace Trains.NET.Rendering
     [Order(450)]
     public class TrackLayoutRenderer : CachableLayoutRenderer<Track>
     {
-        public TrackLayoutRenderer(ILayout<Track> layout, IEnumerable<IRenderer<Track>> renderers, IImageFactory imageFactory, ITerrainMap terrainMap)
-                : base(layout, renderers, imageFactory, terrainMap)
+        public TrackLayoutRenderer(ILayout<Track> layout, IEnumerable<IRenderer<Track>> renderers, IImageFactory imageFactory, ITerrainMap terrainMap, IImageCache imageCache)
+                : base(layout, renderers, imageFactory, terrainMap, imageCache)
         {
             this.Name = "Tracks";
             this.Enabled = true;


### PR DESCRIPTION
Bored on a Thursday!

This PR does a few things:

* Move screen rendering to be done on each frame, to a back buffer
* Draw the screen buffers when updating UI
* Add an image cache service that handles back buffers
* Make everything use the new image cache service instead of ad-hoc dictionaries
* Move from IsDirty flag to Changed event for better invalidation of back buffers