### PR TITLE
Add train sounds

### DIFF
--- a/src/Trains.NET.Comet/MainPage.cs
+++ b/src/Trains.NET.Comet/MainPage.cs
@@ -6,6 +6,7 @@ using Comet;
 using SkiaSharp;
 using SkiaSharp.Views.WPF;
 using Trains.NET.Engine;
+using Trains.NET.Engine.Sounds;
 using Trains.NET.Instrumentation;
 using Trains.NET.Rendering;
 using Trains.NET.Rendering.Skia;
@@ -33,7 +34,8 @@ namespace Trains.NET.Comet
                         IGameStorage gameStorage,
                         ITerrainMap terrainMap,
                         TrainsDelegate trainsDelegate,
-                        IInteractionManager interactionManager)
+                        IInteractionManager interactionManager,
+                        ISoundGenerator soundGenerator)
         {
             this.Title("Trains - " + ThisAssembly.AssemblyInformationalVersion);
 
@@ -66,7 +68,13 @@ namespace Trains.NET.Comet
                         },
                         new Spacer(),
                         new Button("Snapshot", () => Snapshot()),
-                        new Button("Configuration", ()=> _configurationShown.Value = !_configurationShown.Value)
+                        new Button("Configuration", ()=> _configurationShown.Value = !_configurationShown.Value),
+                        new ToggleButton("Sound", soundGenerator.IsRunning, () => {
+                            if(soundGenerator.IsRunning)
+                                 soundGenerator.Stop();
+                            else
+                                 soundGenerator.Start();
+                        }),
                     }.Frame(100, alignment: Alignment.Top),
                     new VStack()
                     {

--- a/src/Trains.NET.Engine/Sounds/ISoundGenerator.cs
+++ b/src/Trains.NET.Engine/Sounds/ISoundGenerator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Trains.NET.Engine.Sounds
+{
+    public interface ISoundGenerator : IDisposable
+    {
+        bool IsRunning { get; }
+        void Start();
+        void Stop();
+    }
+}

--- a/src/Trains/Sounds/HornModel.cs
+++ b/src/Trains/Sounds/HornModel.cs
@@ -1,0 +1,13 @@
+﻿namespace Trains.Sounds
+{
+    public enum HornModel
+    {
+        LeslieS3L,
+        LeslieS5T,
+        NathanP3,
+        NathanK3LA,
+        NathanM3H,
+        NathanK5H1,
+        NathanK5H2,
+    }
+}

--- a/src/Trains/Sounds/MidiHornDef.cs
+++ b/src/Trains/Sounds/MidiHornDef.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Trains.Sounds
+{
+    internal sealed record MidiHornDef
+    {
+        // Taken from https://www.youtube.com/watch?v=yLBinl2sQp8
+
+        //Leslie S3L - C D# A
+        public static readonly MidiHornDef LeslieS3L = new MidiHornDef(MidiNotes.C, MidiNotes.DSharp, MidiNotes.A);
+
+        //Leslie S5T - C D# F# A C#   60, 63, 66, 69, 73
+        public static readonly MidiHornDef LeslieS5T = new MidiHornDef(MidiNotes.C, MidiNotes.DSharp, MidiNotes.FSharp, MidiNotes.A, MidiNotes.CSharp);
+
+        //Nathan P3 - C# E A
+        public static readonly MidiHornDef NathanP3 = new MidiHornDef(MidiNotes.CSharp, MidiNotes.E, MidiNotes.A);
+
+        //Nathan K3LA/K3H - D# F# B
+        public static readonly MidiHornDef NathanK3LA = new MidiHornDef(MidiNotes.DSharp, MidiNotes.FSharp, MidiNotes.B);
+
+        //Nathan M3H - D# F# A#
+        public static readonly MidiHornDef NathanM3H = new MidiHornDef(MidiNotes.DSharp, MidiNotes.FSharp, MidiNotes.ASharp);
+
+        //Nathan K5H - 
+        // Option 1 - D# F# A# C D# 
+        public static readonly MidiHornDef NathanK5H1 = new MidiHornDef(MidiNotes.DSharp, MidiNotes.FSharp, MidiNotes.ASharp, MidiNotes.C, MidiNotes.DSharp);
+        // Option 2 - E G B C# E
+        public static readonly MidiHornDef NathanK5H2 = new MidiHornDef(MidiNotes.E, MidiNotes.G, MidiNotes.B, MidiNotes.CSharp, MidiNotes.E);
+
+        public MidiNotes[] Notes { get; }
+
+        private MidiHornDef(params MidiNotes[] notes)
+        {
+            this.Notes = notes;
+        }
+
+        internal static MidiHornDef GetHorn(HornModel horn) => horn switch
+        {
+            HornModel.LeslieS3L => MidiHornDef.LeslieS3L,
+            HornModel.LeslieS5T => MidiHornDef.LeslieS5T,
+            HornModel.NathanK3LA => MidiHornDef.NathanK3LA,
+            HornModel.NathanK5H1 => MidiHornDef.NathanK5H1,
+            HornModel.NathanK5H2 => MidiHornDef.NathanK5H2,
+            HornModel.NathanM3H => MidiHornDef.NathanM3H,
+            HornModel.NathanP3 => MidiHornDef.NathanP3,
+            _ => throw new NotSupportedException($"Unsupported horn model: {horn}"),
+        };
+    }
+}

--- a/src/Trains/Sounds/MidiNotes.cs
+++ b/src/Trains/Sounds/MidiNotes.cs
@@ -1,0 +1,18 @@
+﻿namespace Trains.Sounds
+{
+    internal enum MidiNotes
+    {
+        C = 60,
+        CSharp = 61,
+        D = 62,
+        DSharp = 63,
+        E = 64,
+        F = 65,
+        FSharp = 66,
+        G = 67,
+        GSharp = 68,
+        A = 69,
+        ASharp = 70,
+        B = 71,
+    }
+}

--- a/src/Trains/Sounds/MidiSynth.cs
+++ b/src/Trains/Sounds/MidiSynth.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Threading.Tasks;
+using Midi;
+
+namespace Trains.Sounds
+{
+    internal sealed class MidiSynth : IDisposable
+    {
+        private readonly object _lock = new object();
+        private Win32API.HMIDIOUT _handle;
+
+        public void Init()
+        {
+            // Find the built in MIDI synth
+            uint num = Win32API.midiOutGetNumDevs();
+            Win32API.MIDIOUTCAPS caps = default;
+            var deviceId = UIntPtr.Zero;
+            bool deviceFound = false;
+            for (uint i = 0; i < num; i++)
+            {
+                Win32API.midiOutGetDevCaps((UIntPtr)i, out caps);
+                if (caps.szPname == "Microsoft GS Wavetable Synth")
+                {
+                    deviceId = (UIntPtr)i;
+                    deviceFound = true;
+                    break;
+                }
+            }
+
+            if (deviceFound)
+            {
+                lock (_lock)
+                {
+                    Win32API.midiOutOpen(out _handle, deviceId, null, (UIntPtr)0);
+                }
+                // Swtich to GS mode
+                GsReset();
+            }
+        }
+
+        internal void Train()
+        {
+            const byte channel = 11;
+            SetGS(channel, 125, 6, 60);
+        }
+
+        internal async Task SoundAsync(HornModel horn, int milliseconds)
+        {
+            var hornDef = MidiHornDef.GetHorn(horn);
+            for (byte i = 0; i < hornDef.Notes.Length; i++)
+            {
+                SendShortMessage(EncodeProgramChange(i, 110));
+                SendShortMessage(EncodeNoteOn(i, (int)hornDef.Notes[i], 127));
+            }
+            await Task.Delay(milliseconds).ConfigureAwait(false);
+            for (byte i = 0; i < hornDef.Notes.Length; i++)
+            {
+                SendShortMessage(EncodeNoteOff(i, (int)hornDef.Notes[i], 0));
+            }
+        }
+
+        internal async Task TweetAsync()
+        {
+            const byte channel = 12;
+            if (Environment.TickCount % 2 == 0)
+                SetGS(channel, 123, 0, 60);
+            else
+                SetGS(channel, 123, 3, 60);
+
+            await Task.Delay(150).ConfigureAwait(false);
+            SendShortMessage(EncodeNoteOff(channel, 60, 127));
+        }
+
+        internal async Task WhistleAsync()
+        {
+            const byte channel = 13;
+            SendShortMessage(EncodeProgramChange(channel, 78));
+            SendShortMessage(EncodeNoteOn(channel, 60, 127));
+
+            await Task.Delay(1500).ConfigureAwait(false);
+            SendShortMessage(EncodeNoteOff(channel, 60, 127));
+        }
+
+        private void GsReset()
+        {
+            var bytes = new byte[] { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7 };
+            SendSysEx(bytes);
+        }
+
+        ////http://battleofthebits.org/lyceum/View/Specification+of+General+MIDI+and+Roland+MT-32+patches/#Patch%20List%20(channel%2010%20only)
+        private void SetGS(byte channel, byte patch, byte bank, byte note)
+        {
+            SendShortMessage(EncodeControlChange(channel, 0, bank));
+            SendShortMessage(EncodeProgramChange(channel, patch));
+            SendShortMessage(EncodeNoteOn(channel, (int)note, 127));
+        }
+
+        private void SendShortMessage(uint message)
+        {
+            lock (_lock)
+            {
+                if (_handle.handle != IntPtr.Zero)
+            {
+                    Win32API.midiOutShortMsg(_handle, message);
+                }
+            }
+        }
+
+        private static uint EncodeProgramChange(int channel, int instrument)
+        {
+            return (uint)(0xC0 | (int)channel | ((int)instrument << 8));
+        }
+
+        private static uint EncodeNoteOn(int channel, int pitch, int velocity)
+        {
+            return (uint)(0x90 | (int)channel | ((int)pitch << 8) | (velocity << 16));
+        }
+
+        private static uint EncodeNoteOff(int channel, int pitch, int velocity)
+        {
+            return (uint)(0x80 | (int)channel | ((int)pitch << 8) | (velocity << 16));
+        }
+
+        private static uint EncodeControlChange(int channel, int control, int value)
+        {
+            return (uint)(0xB0 | (int)channel | ((int)control << 8) | (value << 16));
+        }
+
+        //https://csharp.hotexamples.com/examples/Midi/Win32API.MIDIHDR/-/php-win32api.midihdr-class-examples.html
+        /// <summary>
+        /// Sends a System Exclusive (sysex) message to this MIDI output device.
+        /// </summary>
+        /// <param name="data">The message to send (as byte array)</param>
+        /// <exception cref="DeviceException">The message cannot be sent.</exception>
+        private void SendSysEx(byte[] data)
+        {
+            if (_handle.handle == IntPtr.Zero)
+                return;
+
+            lock (_lock)
+            {
+                //Win32API.MMRESULT result;
+                IntPtr ptr;
+                uint size = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Win32API.MIDIHDR));
+                Win32API.MIDIHDR header = new Win32API.MIDIHDR();
+                header.lpData = System.Runtime.InteropServices.Marshal.AllocHGlobal(data.Length);
+                for (int i = 0; i < data.Length; i++)
+                    System.Runtime.InteropServices.Marshal.WriteByte(header.lpData, i, data[i]);
+                header.dwBufferLength = data.Length;
+                header.dwBytesRecorded = data.Length;
+                header.dwFlags = 0;
+
+                try
+                {
+                    ptr = System.Runtime.InteropServices.Marshal.AllocHGlobal(System.Runtime.InteropServices.Marshal.SizeOf(typeof(Win32API.MIDIHDR)));
+                }
+                catch (Exception)
+                {
+                    System.Runtime.InteropServices.Marshal.FreeHGlobal(header.lpData);
+                    throw;
+                }
+
+                try
+                {
+                    System.Runtime.InteropServices.Marshal.StructureToPtr(header, ptr, false);
+                }
+                catch (Exception)
+                {
+                    System.Runtime.InteropServices.Marshal.FreeHGlobal(header.lpData);
+                    System.Runtime.InteropServices.Marshal.FreeHGlobal(ptr);
+                    throw;
+                }
+
+                var result = Win32API.midiOutPrepareHeader(_handle, ptr, size);
+                if (result == 0) result = Win32API.midiOutLongMsg(_handle, ptr, size);
+                if (result == 0) result = Win32API.midiOutUnprepareHeader(_handle, ptr, size);
+
+                System.Runtime.InteropServices.Marshal.FreeHGlobal(header.lpData);
+                System.Runtime.InteropServices.Marshal.FreeHGlobal(ptr);
+            }
+        }
+
+        public void Close()
+        {
+            lock (_lock)
+            {
+                if (_handle.handle != IntPtr.Zero)
+                {
+                    Win32API.midiOutClose(_handle);
+                    _handle.handle = IntPtr.Zero;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
+}

--- a/src/Trains/Sounds/Win32API.cs
+++ b/src/Trains/Sounds/Win32API.cs
@@ -1,0 +1,501 @@
+﻿// Copyright (c) 2009, Tom Lokovic
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Midi
+{
+    /// <summary>
+    /// C# wrappers for the Win32 MIDI API.
+    /// </summary>
+    /// Because .NET does not provide MIDI support itself, in C# we must use P/Invoke to wrap the
+    /// Win32 API.  That API consists of the MMSystem.h C header and the winmm.dll library.  The API
+    /// is described in detail here: http://msdn.microsoft.com/en-us/library/ms712733(VS.85).aspx.
+    /// The P/Invoke interop mechanism is described here:
+    /// http://msdn.microsoft.com/en-us/library/aa288468(VS.71).aspx.
+    ///
+    /// This file covers the subset of the MIDI protocol needed to manage input and output devices
+    /// and send and receive Note On/Off, Control Change, Pitch Bend and Program Change messages.
+    /// Other portions of the MIDI protocol (such as sysex events) are supported in the Win32 API
+    /// but are not wrapped here.
+    ///
+    /// Some of the C functions are not typesafe when wrapped, so those wrappers are made private
+    /// and typesafe variants are provided.
+
+    [SuppressMessage("Design", "CA1069:Enums values should not be duplicated")]
+    [SuppressMessage("Style", "IDE1006:Naming Styles")]
+    internal static class Win32API
+    {
+        #region Constants
+
+        // The following constants come from MMSystem.h.
+
+        /// <summary>
+        /// Max length of a manufacturer name in the Win32 API.
+        /// </summary>
+        public const uint MAXPNAMELEN = 32;
+
+
+        /// <summary>
+        /// Status type returned from most functions in the Win32 API.
+        /// </summary>
+        public enum MMRESULT : uint
+        {
+            // General return codes.
+            MMSYSERR_BASE = 0,
+            MMSYSERR_NOERROR = MMSYSERR_BASE + 0,
+            MMSYSERR_ERROR = MMSYSERR_BASE + 1,
+            MMSYSERR_BADDEVICEID = MMSYSERR_BASE + 2,
+            MMSYSERR_NOTENABLED = MMSYSERR_BASE + 3,
+            MMSYSERR_ALLOCATED = MMSYSERR_BASE + 4,
+            MMSYSERR_INVALHANDLE = MMSYSERR_BASE + 5,
+            MMSYSERR_NODRIVER = MMSYSERR_BASE + 6,
+            MMSYSERR_NOMEM = MMSYSERR_BASE + 7,
+            MMSYSERR_NOTSUPPORTED = MMSYSERR_BASE + 8,
+            MMSYSERR_BADERRNUM = MMSYSERR_BASE + 9,
+            MMSYSERR_INVALFLAG = MMSYSERR_BASE + 10,
+            MMSYSERR_INVALPARAM = MMSYSERR_BASE + 11,
+            MMSYSERR_HANDLEBUSY = MMSYSERR_BASE + 12,
+            MMSYSERR_INVALIDALIAS = MMSYSERR_BASE + 13,
+            MMSYSERR_BADDB = MMSYSERR_BASE + 14,
+            MMSYSERR_KEYNOTFOUND = MMSYSERR_BASE + 15,
+            MMSYSERR_READERROR = MMSYSERR_BASE + 16,
+            MMSYSERR_WRITEERROR = MMSYSERR_BASE + 17,
+            MMSYSERR_DELETEERROR = MMSYSERR_BASE + 18,
+            MMSYSERR_VALNOTFOUND = MMSYSERR_BASE + 19,
+            MMSYSERR_NODRIVERCB = MMSYSERR_BASE + 20,
+            MMSYSERR_MOREDATA = MMSYSERR_BASE + 21,
+            MMSYSERR_LASTERROR = MMSYSERR_BASE + 21,
+
+            // MIDI-specific return codes.
+            MIDIERR_BASE = 64,
+            MIDIERR_UNPREPARED = MIDIERR_BASE + 0,
+            MIDIERR_STILLPLAYING = MIDIERR_BASE + 1,
+            MIDIERR_NOMAP = MIDIERR_BASE + 2,
+            MIDIERR_NOTREADY = MIDIERR_BASE + 3,
+            MIDIERR_NODEVICE = MIDIERR_BASE + 4,
+            MIDIERR_INVALIDSETUP = MIDIERR_BASE + 5,
+            MIDIERR_BADOPENMODE = MIDIERR_BASE + 6,
+            MIDIERR_DONT_CONTINUE = MIDIERR_BASE + 7,
+            MIDIERR_LASTERROR = MIDIERR_BASE + 7
+        }
+
+        /// <summary>
+        /// Flags passed to midiInOpen() and midiOutOpen().
+        /// </summary>
+        public enum MidiOpenFlags : uint
+        {
+            CALLBACK_TYPEMASK = 0x70000,
+            CALLBACK_NULL = 0x00000,
+            CALLBACK_WINDOW = 0x10000,
+            CALLBACK_TASK = 0x20000,
+            CALLBACK_FUNCTION = 0x30000,
+            CALLBACK_THREAD = CALLBACK_TASK,
+            CALLBACK_EVENT = 0x50000,
+            MIDI_IO_STATUS = 0x00020
+        }
+
+        /// <summary>
+        /// Values for wTechnology field of MIDIOUTCAPS structure.
+        /// </summary>
+        public enum MidiDeviceType : ushort
+        {
+            MOD_MIDIPORT = 1,
+            MOD_SYNTH = 2,
+            MOD_SQSYNTH = 3,
+            MOD_FMSYNTH = 4,
+            MOD_MAPPER = 5,
+            MOD_WAVETABLE = 6,
+            MOD_SWSYNTH = 7
+        }
+
+        /// <summary>
+        /// Flags for dwSupport field of MIDIOUTCAPS structure.
+        /// </summary>
+        public enum MidiExtraFeatures : uint
+        {
+            MIDICAPS_VOLUME = 0x0001,
+            MIDICAPS_LRVOLUME = 0x0002,
+            MIDICAPS_CACHE = 0x0004,
+            MIDICAPS_STREAM = 0x0008
+        }
+
+        /// <summary>
+        /// "Midi Out Messages", passed to wMsg param of MidiOutProc.
+        /// </summary>
+        public enum MidiOutMessage : uint
+        {
+            MOM_OPEN = 0x3C7,
+            MOM_CLOSE = 0x3C8,
+            MOM_DONE = 0x3C9
+        }
+
+        /// <summary>
+        /// "Midi In Messages", passed to wMsg param of MidiInProc.
+        /// </summary>
+        public enum MidiInMessage : uint
+        {
+            MIM_OPEN = 0x3C1,
+            MIM_CLOSE = 0x3C2,
+            MIM_DATA = 0x3C3,
+            MIM_LONGDATA = 0x3C4,
+            MIM_ERROR = 0x3C5,
+            MIM_LONGERROR = 0x3C6,
+            MIM_MOREDATA = 0x3CC
+        }
+
+        #endregion
+
+        #region Handles
+
+        /// <summary>
+        /// Win32 handle for a MIDI output device.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct HMIDIOUT
+        {
+            public IntPtr handle;
+        }
+
+        /// <summary>
+        /// Win32 handle for a MIDI input device.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct HMIDIIN
+        {
+            public IntPtr handle;
+        }
+
+        #endregion
+
+        #region Structs
+
+        /// <summary>
+        /// Struct representing the capabilities of an output device. 
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711619(VS.85).aspx
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MIDIOUTCAPS
+        {
+            public ushort wMid;
+            public ushort wPid;
+            public uint vDriverVersion;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = (int)MAXPNAMELEN)]
+            public string szPname;
+            public MidiDeviceType wTechnology;
+            public ushort wVoices;
+            public ushort wNotes;
+            public ushort wChannelMask;
+            public MidiExtraFeatures dwSupport;
+        }
+
+        /// <summary>
+        /// Struct representing the capabilities of an input device. 
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711596(VS.85).aspx
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MIDIINCAPS
+        {
+            public ushort wMid;
+            public ushort wPid;
+            public uint vDriverVersion;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = (int)MAXPNAMELEN)]
+            public string szPname;
+            public uint dwSupport;
+        }
+
+        #region SysEx
+
+        /// <summary>
+        /// Strut to hold outgoing long messages (sysex)
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711592(v=VS.85).aspx
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MIDIHDR
+        {
+            public IntPtr lpData;
+            public int dwBufferLength;
+            public int dwBytesRecorded;
+            public IntPtr dwUser;
+            public int dwFlags;
+            public IntPtr lpNext;
+            public IntPtr reserved;
+            public int dwOffset;
+
+            //public IntPtr dwReserved;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public int[] reservedArray;
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Functions for MIDI Output
+
+        /// <summary>
+        /// Returns the number of MIDI output devices on this system.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711627(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern uint midiOutGetNumDevs();
+
+        /// <summary>
+        /// Fills in the capabilities struct for a specific output device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711621(VS.85).aspx
+        public static MMRESULT midiOutGetDevCaps(UIntPtr uDeviceID, out MIDIOUTCAPS caps)
+        {
+            return midiOutGetDevCaps(uDeviceID, out caps,
+                (uint)Marshal.SizeOf(typeof(MIDIOUTCAPS)));
+        }
+
+        /// <summary>
+        /// Callback invoked when a MIDI output device is opened, closed, or finished with a buffer.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711637(VS.85).aspx
+        public delegate void MidiOutProc(HMIDIOUT hmo, MidiOutMessage wMsg, UIntPtr dwInstance,
+            UIntPtr dwParam1, UIntPtr dwParam2);
+
+        /// <summary>
+        /// Opens a MIDI output device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711632(VS.85).aspx
+        public static MMRESULT midiOutOpen(out HMIDIOUT lphmo, UIntPtr uDeviceID,
+                                         MidiOutProc? dwCallback, UIntPtr dwCallbackInstance)
+        {
+            //return midiOutOpen(out lphmo, uDeviceID, dwCallback, dwCallbackInstance,
+            //    dwCallback == null ? MidiOpenFlags.CALLBACK_NULL : MidiOpenFlags.CALLBACK_FUNCTION);
+            #region SysEx
+            return midiOutOpen(out lphmo, uDeviceID, dwCallback, dwCallbackInstance,
+                dwCallback == null ? MidiOpenFlags.CALLBACK_NULL : MidiOpenFlags.CALLBACK_FUNCTION & MidiOpenFlags.MIDI_IO_STATUS);
+            #endregion
+        }
+
+        /// <summary>
+        /// Turns off all notes and sustains on a MIDI output device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/dd798479(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutReset(HMIDIOUT hmo);
+
+        /// <summary>
+        /// Closes a MIDI output device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711620(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutClose(HMIDIOUT hmo);
+
+        /// <summary>
+        /// Sends a short MIDI message (anything but sysex or stream).
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711640(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutShortMsg(HMIDIOUT hmo, uint dwMsg);
+
+        #region SysEx
+
+        /// <summary>
+        /// Sends a long MIDI message (sysex).
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711629(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutLongMsg(HMIDIOUT hmo, IntPtr lpMidiOutHdr, uint cbMidiOutHdr);
+        // MMRESULT midiOutLongMsg(HMIDIOUT hmo, LPMIDIHDR lpMidiOutHdr, UINT cbMidiOutHdr);
+
+        /// <summary>
+        /// Prepares a long message for sending
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711634(v=VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutPrepareHeader(HMIDIOUT hmo, IntPtr lpMidiOutHdr, uint cbMidiOutHdr);
+
+        /// <summary>
+        /// Frees header space after sending long message
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711641(v=VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiOutUnprepareHeader(HMIDIOUT hmo, IntPtr lpMidiOutHdr, uint cbMidiOutHdr);
+
+        #endregion
+
+        /// <summary>
+        /// Gets the error text for a return code related to an output device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711622(VS.85).aspx
+        public static MMRESULT midiOutGetErrorText(MMRESULT mmrError, StringBuilder lpText)
+        {
+            return midiOutGetErrorText(mmrError, lpText, (uint)lpText.Capacity);
+        }
+
+        #endregion
+
+        #region Functions for MIDI Input
+
+        /// <summary>
+        /// Returns the number of MIDI input devices on this system.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711608(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern uint midiInGetNumDevs();
+
+        /// <summary>
+        /// Fills in the capabilities struct for a specific input device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711604(VS.85).aspx
+        public static MMRESULT midiInGetDevCaps(UIntPtr uDeviceID, out MIDIINCAPS caps)
+        {
+            return midiInGetDevCaps(uDeviceID, out caps,
+                (uint)Marshal.SizeOf(typeof(MIDIINCAPS)));
+        }
+
+        /// <summary>
+        /// Callback invoked when a MIDI event is received from an input device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711612(VS.85).aspx
+        public delegate void MidiInProc(HMIDIIN hMidiIn, MidiInMessage wMsg, UIntPtr dwInstance,
+            UIntPtr dwParam1, UIntPtr dwParam2);
+
+        /// <summary>
+        /// Opens a MIDI input device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711610(VS.85).aspx
+        public static MMRESULT midiInOpen(out HMIDIIN lphMidiIn, UIntPtr uDeviceID,
+                                          MidiInProc dwCallback, UIntPtr dwCallbackInstance)
+        {
+            return midiInOpen(out lphMidiIn, uDeviceID, dwCallback, dwCallbackInstance,
+                dwCallback == null ? MidiOpenFlags.CALLBACK_NULL : MidiOpenFlags.CALLBACK_FUNCTION);
+        }
+
+        /// <summary>
+        /// Starts input on a MIDI input device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711614(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInStart(HMIDIIN hMidiIn);
+
+        /// <summary>
+        /// Stops input on a MIDI input device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711615(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInStop(HMIDIIN hMidiIn);
+
+        /// <summary>
+        /// Resets input on a MIDI input device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711613(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInReset(HMIDIIN hMidiIn);
+
+        /// <summary>
+        /// Closes a MIDI input device.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711602(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInClose(HMIDIIN hMidiIn);
+
+        /// <summary>
+        /// Gets the error text for a return code related to an input device.
+        /// </summary>
+        /// NOTE: This is adapted from the original Win32 function in order to make it typesafe.
+        ///
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/ms711605(VS.85).aspx
+        public static MMRESULT midiInGetErrorText(MMRESULT mmrError, StringBuilder lpText)
+        {
+            return midiInGetErrorText(mmrError, lpText, (uint)lpText.Capacity);
+        }
+
+        #region SysEx
+
+        /// <summary>
+        /// Send a buffer to and input device in order to receive SysEx messages.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/dd798450(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInAddBuffer(HMIDIIN hMidiIn, IntPtr lpMidiInHdr, uint cbMidiInHdr);
+
+        /// <summary>
+        /// Prepare an input buffer before passing to midiInAddBuffer.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/dd798459(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInPrepareHeader(HMIDIIN hMidiIn, IntPtr headerPtr, uint cbMidiInHdr);
+
+        /// <summary>
+        /// Clean up preparation performed by midiInPrepareHeader.
+        /// </summary>
+        /// Win32 docs: http://msdn.microsoft.com/en-us/library/dd798464(VS.85).aspx
+        [DllImport("winmm.dll", SetLastError = true)]
+        public static extern MMRESULT midiInUnprepareHeader(HMIDIIN hMidiIn, IntPtr headerPtr, uint cbMidiInHdr);
+
+        #endregion
+
+        #endregion
+
+        #region Non-Typesafe Bindings
+
+        // The bindings in this section are not typesafe, so we make them private and privide
+        // typesafe variants above.
+
+        [DllImport("winmm.dll", SetLastError = true)]
+        private static extern MMRESULT midiOutGetDevCaps(UIntPtr uDeviceID, out MIDIOUTCAPS caps,
+            uint cbMidiOutCaps);
+
+        [DllImport("winmm.dll", SetLastError = true)]
+        private static extern MMRESULT midiOutOpen(out HMIDIOUT lphmo, UIntPtr uDeviceID,
+            MidiOutProc? dwCallback, UIntPtr dwCallbackInstance, MidiOpenFlags dwFlags);
+
+        [DllImport("winmm.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern MMRESULT midiOutGetErrorText(MMRESULT mmrError, StringBuilder lpText,
+            uint cchText);
+
+        [DllImport("winmm.dll", SetLastError = true)]
+        private static extern MMRESULT midiInGetDevCaps(UIntPtr uDeviceID, out MIDIINCAPS caps,
+            uint cbMidiInCaps);
+
+        [DllImport("winmm.dll", SetLastError = true)]
+        private static extern MMRESULT midiInOpen(out HMIDIIN lphMidiIn, UIntPtr uDeviceID,
+            MidiInProc dwCallback, UIntPtr dwCallbackInstance, MidiOpenFlags dwFlags);
+
+        [DllImport("winmm.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern MMRESULT midiInGetErrorText(MMRESULT mmrError, StringBuilder lpText,
+            uint cchText);
+
+        #endregion    
+    }
+}

--- a/src/Trains/Sounds/WindowsSoundGenerator.cs
+++ b/src/Trains/Sounds/WindowsSoundGenerator.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Trains.NET.Engine.Sounds;
+
+namespace Trains.Sounds
+{
+    public sealed class WindowsSoundGenerator : ISoundGenerator
+    {
+        private readonly MidiSynth _synth;
+
+        public bool IsRunning { get; private set; }
+
+        public WindowsSoundGenerator()
+        {
+            _synth = new MidiSynth();
+        }
+
+        public void Start()
+        {
+            if (!this.IsRunning)
+            {
+                this.IsRunning = true;
+                _synth.Init();
+                Task.Run(async () => await RunLoopAsync().ConfigureAwait(false)); ;
+            }
+        }
+
+        public void Stop()
+        {
+            if (this.IsRunning)
+            {
+                this.IsRunning = false;
+                _synth.Close();
+            }
+        }
+
+        private async Task RunLoopAsync()
+        {
+
+            var random = new Random();
+
+            _synth.Train();
+            while (this.IsRunning)
+            {
+                switch (random.Next(0, 20))
+                {
+                    case 0:
+                        await _synth.SoundAsync(HornModel.NathanK3LA, random.Next(1000, 3000)).ConfigureAwait(false);
+                        break;
+                    case 1 or 2:
+                        await _synth.WhistleAsync().ConfigureAwait(false);
+                        break;
+                    case >= 3 and <= 6:
+                        await _synth.TweetAsync().ConfigureAwait(false);
+                        break;
+                }
+                await Task.Delay(random.Next(500, 3000)).ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            _synth.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
It turns out that Windows has a built in MIDI synth that can generate train sounds!

Added models for a number of train horns [based on this YouTube](https://www.youtube.com/watch?v=yLBinl2sQp8), but the Nathan K3LA sounds best (IMHO).

Adds the occasional tweet in anticipation of birds being added.

Originally tried to access MIDI via the UWP apis, but there is a bug that means you can't put the synth into GS mode which is required to select the train sound (Patch 125, bank 6) so had to use the Win32 api instead.