### PR TITLE
Added Saving and loading using BlazoredStorage using the sync API

### DIFF
--- a/src/BlazingTrains/BlazorGameStorage.cs
+++ b/src/BlazingTrains/BlazorGameStorage.cs
@@ -1,4 +1,5 @@
-﻿using Trains.NET.Engine;
+﻿using Blazored.LocalStorage;
+using Trains.NET.Engine;
 
 namespace BlazingTrains;
 
@@ -6,14 +7,16 @@ public class BlazorGameStorage : IGameStorage
 {
     public IServiceProvider? AspNetCoreServices { get; set; }
 
-    //private ILocalStorageService? LocalStorageService => this.AspNetCoreServices?.GetService<ILocalStorageService>();
+    private ISyncLocalStorageService? SyncLocalStorageService => this.AspNetCoreServices?.GetService<ISyncLocalStorageService>();
 
     public string? Read(string key)
     {
-        return null;
+        var data = this.SyncLocalStorageService?.GetItemAsString(key);
+        return data;
     }
 
     public void Write(string key, string value)
     {
+        this.SyncLocalStorageService?.SetItemAsString(key, value);
     }
 }

--- a/src/BlazingTrains/BlazorGameStorage.cs
+++ b/src/BlazingTrains/BlazorGameStorage.cs
@@ -15,8 +15,13 @@ public class BlazorGameStorage : IGameStorage
         return data;
     }
 
+
+    Dictionary<string, string> _lastSavedValue = new Dictionary<string, string>();
     public void Write(string key, string value)
     {
-        this.SyncLocalStorageService?.SetItemAsString(key, value);
+        if (!_lastSavedValue.TryGetValue(key, out var previousValue) || previousValue != value)
+        {
+            this.SyncLocalStorageService?.SetItemAsString(key, value);
+        }
     }
 }

--- a/src/BlazingTrains/BlazorGameStorage.cs
+++ b/src/BlazingTrains/BlazorGameStorage.cs
@@ -16,11 +16,13 @@ public class BlazorGameStorage : IGameStorage
     }
 
 
-    Dictionary<string, string> _lastSavedValue = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> _lastSavedValue = new Dictionary<string, string>();
     public void Write(string key, string value)
     {
-        if (!_lastSavedValue.TryGetValue(key, out var previousValue) || previousValue != value)
+        var valueExists = _lastSavedValue.TryGetValue(key, out var previousValue);
+        if (!valueExists || previousValue != value)
         {
+            _lastSavedValue[key] = value;
             this.SyncLocalStorageService?.SetItemAsString(key, value);
         }
     }

--- a/src/BlazingTrains/BlazorGameStorage.cs
+++ b/src/BlazingTrains/BlazorGameStorage.cs
@@ -15,7 +15,6 @@ public class BlazorGameStorage : IGameStorage
         return data;
     }
 
-
     private readonly Dictionary<string, string> _lastSavedValue = new Dictionary<string, string>();
     public void Write(string key, string value)
     {

--- a/src/BlazingTrains/Commands/ChangeSaveModeCommand.cs
+++ b/src/BlazingTrains/Commands/ChangeSaveModeCommand.cs
@@ -11,7 +11,7 @@ public class ChangeSaveModeCommand : ICommand
         _gameStateManager = gameStateManager;
     }
 
-    public string Name => $"Change Auto Save Mode";
+    public string Name => $"Change Save Mode";
 
     public void Execute()
     {

--- a/src/BlazingTrains/Commands/ChangeSaveModeCommand.cs
+++ b/src/BlazingTrains/Commands/ChangeSaveModeCommand.cs
@@ -1,0 +1,20 @@
+﻿using Trains.NET.Engine;
+
+namespace BlazingTrains.Commands;
+
+public class ChangeSaveModeCommand : ICommand
+{
+    private readonly IGameStateManager _gameStateManager;
+
+    public ChangeSaveModeCommand(IGameStateManager gameStateManager)
+    {
+        _gameStateManager = gameStateManager;
+    }
+
+    public string Name => $"Change Auto Save Mode";
+
+    public void Execute()
+    {
+        _gameStateManager.ChangeSaveMode();
+    }
+}

--- a/src/BlazingTrains/Commands/SaveCommand.cs
+++ b/src/BlazingTrains/Commands/SaveCommand.cs
@@ -1,0 +1,21 @@
+﻿using Trains.NET.Engine;
+
+namespace BlazingTrains.Commands;
+
+[Order(150)]
+
+public class SaveCommand : ICommand
+{
+    public string Name => "Save";
+    private readonly IGameStateManager _gameStateManager;
+
+    public SaveCommand(IGameStateManager gameStateManager)
+    {
+        _gameStateManager = gameStateManager;
+    }
+
+    public void Execute()
+    {
+        _gameStateManager.Save();
+    }
+}

--- a/src/Trains.NET.Engine/GamePlay/GameManager.cs
+++ b/src/Trains.NET.Engine/GamePlay/GameManager.cs
@@ -73,7 +73,9 @@ public class GameManager : IGameManager, IInitializeAsync
             foreach (var gameStep in _gameSteps)
             {
                 gameStep.Update(timeSinceLastTick);
-                _gameStateManager.Save();
+                //Uncomment this line to enable saving on every game loop step.
+                //On my clunky VM, enabling this increased GameLoopStep time from ~45ms to ~150ms
+                //_gameStateManager.Save();
             }
         }
     }

--- a/src/Trains.NET.Engine/GamePlay/GameManager.cs
+++ b/src/Trains.NET.Engine/GamePlay/GameManager.cs
@@ -14,6 +14,7 @@ public class GameManager : IGameManager, IInitializeAsync
     private ITool _currentTool;
     private readonly ITool _defaultTool;
     private readonly ITimer _gameLoopTimer;
+    private readonly IGameStateManager _gameStateManager;
     private readonly IEnumerable<IGameStep> _gameSteps;
     private readonly ElapsedMillisecondsTimedStat _gameUpdateTime = InstrumentationBag.Add<ElapsedMillisecondsTimedStat>("Game-LoopStepTime");
 
@@ -42,7 +43,7 @@ public class GameManager : IGameManager, IInitializeAsync
         }
     }
 
-    public GameManager(IEnumerable<ITool> tools, IEnumerable<IGameStep> gameSteps, ITimer timer)
+    public GameManager(IEnumerable<ITool> tools, IEnumerable<IGameStep> gameSteps, ITimer timer, IGameStateManager gameStateManager)
     {
         _defaultTool = tools.First();
         _currentTool = _defaultTool;
@@ -52,6 +53,7 @@ public class GameManager : IGameManager, IInitializeAsync
 
         _gameLoopTimer.Interval = GameLoopInterval;
         _gameLoopTimer.Elapsed += GameLoopTimerElapsed;
+        _gameStateManager = gameStateManager;
     }
 
     public Task InitializeAsync(int columns, int rows)
@@ -71,6 +73,7 @@ public class GameManager : IGameManager, IInitializeAsync
             foreach (var gameStep in _gameSteps)
             {
                 gameStep.Update(timeSinceLastTick);
+                _gameStateManager.Save();
             }
         }
     }

--- a/src/Trains.NET.Engine/GamePlay/GameManager.cs
+++ b/src/Trains.NET.Engine/GamePlay/GameManager.cs
@@ -74,7 +74,7 @@ public class GameManager : IGameManager, IInitializeAsync
             foreach (var gameStep in _gameSteps)
             {
                 gameStep.Update(timeSinceLastTick);
-                if(_gameStateManager.SaveMode == SaveModes.GameStep)
+                if (_gameStateManager.SaveMode == SaveModes.GameStep)
                     _gameStateManager.Save();
             }
         }

--- a/src/Trains.NET.Engine/GamePlay/GameManager.cs
+++ b/src/Trains.NET.Engine/GamePlay/GameManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Trains.NET.Engine.Utilities;
 using Trains.NET.Instrumentation;
 
 namespace Trains.NET.Engine;
@@ -73,9 +74,8 @@ public class GameManager : IGameManager, IInitializeAsync
             foreach (var gameStep in _gameSteps)
             {
                 gameStep.Update(timeSinceLastTick);
-                //Uncomment this line to enable saving on every game loop step.
-                //On my clunky VM, enabling this increased GameLoopStep time from ~45ms to ~150ms
-                //_gameStateManager.Save();
+                if(_gameStateManager.SaveMode == SaveModes.GameStep)
+                    _gameStateManager.Save();
             }
         }
     }

--- a/src/Trains.NET.Engine/GameState/GameStateManager.cs
+++ b/src/Trains.NET.Engine/GameState/GameStateManager.cs
@@ -77,10 +77,10 @@ public class GameStateManager : IGameStateManager, IInitializeAsync
     {
         this.SaveMode = this.SaveMode switch
         {
-            SaveModes.Disabled => SaveModes.GameStep,
+            SaveModes.Manual => SaveModes.GameStep,
             SaveModes.GameStep => SaveModes.Timer,
-            SaveModes.Timer => SaveModes.Disabled,
-            _ => SaveModes.Disabled
+            SaveModes.Timer => SaveModes.Manual,
+            _ => SaveModes.Manual
         };
         _saveModeStat.Information = $"{this.SaveMode}";
         if (this.SaveMode == SaveModes.Timer)

--- a/src/Trains.NET.Engine/GameState/GameStateManager.cs
+++ b/src/Trains.NET.Engine/GameState/GameStateManager.cs
@@ -8,18 +8,31 @@ public class GameStateManager : IGameStateManager, IInitializeAsync
 {
     private readonly IEnumerable<IGameState> _gameStates;
     private readonly IGameStorage _storage;
+    private readonly ITimer _timer;
 
-    public GameStateManager(IEnumerable<IGameState> gameStates, IGameStorage storage)
+    public GameStateManager(IEnumerable<IGameState> gameStates, IGameStorage storage, ITimer timer)
     {
         _gameStates = gameStates;
         _storage = storage;
+        _timer = timer;
     }
 
     public Task InitializeAsync(int columns, int rows)
     {
         Load();
 
+        _timer.Interval = 1000;
+        _timer.Elapsed += _timer_Elapsed;
+        //Uncomment this line to enable saving once per second/interval time set above.
+        //On my clunky VM, enabling this increased GameLoopStep time from ~45ms to ~50ms, but that might just be noise and I didn't measure precisely
+        //_timer.Start();
+
         return Task.CompletedTask;
+    }
+
+    private void _timer_Elapsed(object? sender, System.EventArgs e)
+    {
+        Save();
     }
 
     public void Load()

--- a/src/Trains.NET.Engine/GameState/GameStateManager.cs
+++ b/src/Trains.NET.Engine/GameState/GameStateManager.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Trains.NET.Engine.Utilities;
 using Trains.NET.Instrumentation;

--- a/src/Trains.NET.Engine/GameState/IGameStateManager.cs
+++ b/src/Trains.NET.Engine/GameState/IGameStateManager.cs
@@ -1,8 +1,13 @@
-﻿namespace Trains.NET.Engine;
+﻿using Trains.NET.Engine.Utilities;
+
+namespace Trains.NET.Engine;
 
 public interface IGameStateManager
 {
+    SaveModes SaveMode { get; }
+
     void Load();
     void Save();
     void Reset();
+    void ChangeSaveMode();
 }

--- a/src/Trains.NET.Engine/Utilities/SaveModes.cs
+++ b/src/Trains.NET.Engine/Utilities/SaveModes.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Trains.NET.Engine.Utilities;
+﻿namespace Trains.NET.Engine.Utilities;
 
 public enum SaveModes
 {

--- a/src/Trains.NET.Engine/Utilities/SaveModes.cs
+++ b/src/Trains.NET.Engine/Utilities/SaveModes.cs
@@ -8,7 +8,7 @@ namespace Trains.NET.Engine.Utilities;
 
 public enum SaveModes
 {
-    Disabled,
+    Manual,
     GameStep,
     Timer
 }

--- a/src/Trains.NET.Engine/Utilities/SaveModes.cs
+++ b/src/Trains.NET.Engine/Utilities/SaveModes.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Trains.NET.Engine.Utilities;
+
+public enum SaveModes
+{
+    Disabled,
+    GameStep,
+    Timer
+}

--- a/src/Trains.NET.Instrumentation/Stats/InformationStat.cs
+++ b/src/Trains.NET.Instrumentation/Stats/InformationStat.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Trains.NET.Instrumentation.Stats;
+﻿namespace Trains.NET.Instrumentation.Stats;
 
 public class InformationStat : IStat
 {
-    public string Information { get; set; }
-    public string? GetDescription() => this.Information;
+    public string Information { get; set; } = "";
+    public string GetDescription() => this.Information;
     public bool ShouldShow() => !string.IsNullOrWhiteSpace(this.Information);
 }

--- a/src/Trains.NET.Instrumentation/Stats/InformationStat.cs
+++ b/src/Trains.NET.Instrumentation/Stats/InformationStat.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Trains.NET.Instrumentation.Stats;
+
+public class InformationStat : IStat
+{
+    public string Information { get; set; }
+    public string? GetDescription() => this.Information;
+    public bool ShouldShow() => !string.IsNullOrWhiteSpace(this.Information);
+}

--- a/tests/Trains.NET.Tests/NullGameStateManager.cs
+++ b/tests/Trains.NET.Tests/NullGameStateManager.cs
@@ -1,9 +1,16 @@
 ﻿using Trains.NET.Engine;
+using Trains.NET.Engine.Utilities;
 
 namespace Trains.NET.Tests;
 
 internal class NullGameStateManager : IGameStateManager
 {
+    public SaveModes SaveMode { get; private set; }
+
+    public void ChangeSaveMode()
+    {
+    }
+
     public void Load()
     {
     }

--- a/tests/Trains.NET.Tests/TestBase.cs
+++ b/tests/Trains.NET.Tests/TestBase.cs
@@ -43,7 +43,8 @@ public class TestBase : IAsyncLifetime, IDisposable
                 TrackLayout,
                 MovableLayout
             },
-            Timer);
+            Timer,
+            new GameStateManager(Enumerable.Empty<IGameState>(), new NullStorage(), Timer));
 
         TrainManager = new TrainManager(MovableLayout, TrackLayout);
 


### PR DESCRIPTION
I've got saving and loading working. The game automatically loads when initialized. Saving can happen manually by clicking Save in the command popup or can happen automatically.

I've tried two ways of automatically saving. 
* Triggered by the Game Step Loop
* Triggered by a timer that runs once per second
In the Command popup you can change between Manual Saving, Timer Saving and GameStep Loop. The Diagnostics panel displays the current state.

![image](https://user-images.githubusercontent.com/29908924/140643524-f4b294f9-fb04-45d3-aac5-ba2680f7b341.png)

I think timer is probably the best option and we'll end up removing the gamestep option and manual saving, but they're in there for experimenting.

If you want to look at the data that's being saved you can see it in the Application tab in chrom dev tools.
![localstorage](https://user-images.githubusercontent.com/29908924/140643518-d04252ae-8423-4655-a8b8-e9552991a72a.PNG)


